### PR TITLE
[PoC, DO NOT MERGE] fix: makes nonce unique per request

### DIFF
--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -7,12 +7,7 @@ import { SnykStrategyOptions, ProfileFunc, ProfileCallback } from './types';
  * It extends the OAuth2 strategy provided by Passport.js
  */
 export default class SnykOAuth2Strategy extends Strategy {
-  /**
-   * nonce: value is required for Snyk Authentication process
-   * profileFunc: is called is user wants to call any Snyk API
-   * to get profile for their records
-   */
-  private _nonce: string;
+  private _nonce?: string;
   private _profileFunc?: ProfileFunc;
 
   constructor(options: SnykStrategyOptions, verify: VerifyFunctionWithRequest) {
@@ -23,12 +18,15 @@ export default class SnykOAuth2Strategy extends Strategy {
   }
 
   /**
-   * Function adds the nonce value to the URL being called for authentication
+   * Function adds the nonce value to the URL being called for authentication.
+   *
+   * The nonce parameter should be passed through passport.authenticate call.
    */
-  authorizationParams(): any {
-    return {
-      nonce: this._nonce,
-    };
+  authorizationParams({ nonce }: { nonce?: string }): any {
+    // TODO throw when nonce is not passed after the nonce parameter
+    // is deleted from SnykStrategyOptions.
+    const nonceToUse = nonce ?? this._nonce;
+    return nonceToUse ? { nonce: nonceToUse } : {};
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,9 +6,20 @@ export interface SnykStrategyOptions extends StrategyOptionsWithRequest {
   clientID: string;
   clientSecret: string;
   callbackURL: string;
-  nonce: string;
+
+  /**
+   * The nonce is required for Snyk Authentication process.
+   *
+   * @deprecated Pass it in options for passport.authenticate.
+   */
+  nonce?: string;
   scope: string | string[];
   state: any;
+
+  /**
+   * This is called is user wants to call any Snyk API
+   * to get profile for their records.
+   */
   profileFunc?: ProfileFunc;
 }
 

--- a/tests/helpers/setupApp.ts
+++ b/tests/helpers/setupApp.ts
@@ -56,7 +56,6 @@ export function setupExpressApp(): Application {
         scopeSeparator: ' ',
         state: true,
         passReqToCallback: true,
-        nonce: testData.nonce,
         // profileFunc,
       },
       // Callback function called with the

--- a/tests/src/strategy.spec.ts
+++ b/tests/src/strategy.spec.ts
@@ -12,7 +12,13 @@ describe('Strategy with passport', () => {
   const request = supertest(app);
 
   // This will trigger the auth flow
-  app.get('/auth', passport.authenticate('snyk-oauth2', { state: 'test' }));
+  app.get(
+    '/auth',
+    passport.authenticate('snyk-oauth2', {
+      state: 'test',
+      nonce: testData.nonce,
+    } as passport.AuthenticateOptions),
+  );
   app.get(
     '/callback',
     passport.authenticate('snyk-oauth2', {


### PR DESCRIPTION
Hopefully fixes https://github.com/snyk/passport-snyk-oauth2/issues/5

This is needed because currently the nonce is a static value passed to the strategy constructor instead of dynamically adding it to the authenticate call of Passport.js.

This also allows the caller to associate the nonce value with the state to be able to pull it out of some storage for request validation.