### PR TITLE
feat: ability to pass query params for request made through passport

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,31 +1,39 @@
 # @snyk/passport-snyk-oauth2
 
-Snyk's OAuth2 strategy for [Passportjs](https://www.passportjs.org/) to make authenticating Snyk Apps seamless. 
+Snyk's OAuth2 strategy for [Passportjs](https://www.passportjs.org/) to make authenticating Snyk Apps a seamless experience. 
 
 # Intro
 
-We recently launched [Snyk Apps](https://docs.snyk.io/features/integrations/snyk-apps) which allows developers to create their own apps for Snyk and extend the functionality of the Snyk platform. It is available for all languages or framework of your choice. We used [Node.js](https://nodejs.dev/) and [TypeScript](https://www.typescriptlang.org/) to demo the authencition flow and usage of [Snyk Apps](https://docs.snyk.io/features/integrations/snyk-apps) using our [Snyk App Demo](https://github.com/snyk/snyk-apps-demo). In the [Snyk App Demo](https://github.com/snyk/snyk-apps-demo) we use [Passportjs](https://www.passportjs.org/) to make the authentication flow and implementation of the same easier for the user. To further extend this, we have created `@snyk/passport-snyk-oauth2`. This can be easily integrated with [Passportjs](https://www.passportjs.org/) and make your developer experience even better.
+We recently launched [Snyk Apps](https://docs.snyk.io/features/integrations/snyk-apps) which allows developers to create their own apps for Snyk and extend the functionality of the Snyk platform. It is available for all languages or framework of your choice. 
+
+We used [Node.js](https://nodejs.dev/) and [TypeScript](https://www.typescriptlang.org/) to demo the authentication flow and usage of [Snyk Apps](https://docs.snyk.io/features/integrations/snyk-apps) using our [Snyk App Demo](https://github.com/snyk/snyk-apps-demo). 
+
+In the [Snyk App Demo](https://github.com/snyk/snyk-apps-demo) we use [Passportjs](https://www.passportjs.org/) to make the authentication flow and implementation of the same easier for the user. To further extend this, we have created `@snyk/passport-snyk-oauth2`. This can be easily integrated with [Passportjs](https://www.passportjs.org/) and make your developer experience even better.
 
 # Usage
 
 ## Install
 
-```
+```shell
 npm install @snyk/passport-snyk-oauth2
-// or
+```
+or
+```shell
 yarn add @snyk/passport-snyk-oauth2
 ```
 
 ## Configure Strategy
 
-```
+```typescript
 import axios from 'axios';
 import passport from 'passport';
 import SnykOAuth2Strategy from '@snyk/passport-snyk-oauth2';
 
-// User can pass their own implementation of fetching the profile
-// by providing the profileFunc implementation. Snyk OAuth2 strategy
-// will call this function to fetch the profile associated with request
+/**
+ * User can pass their own implementation of fetching the profile
+ * by providing the profileFunc implementation. Snyk OAuth2 strategy
+ * will call this function to fetch the profile associated with request
+ */
 const profileFunc: ProfileFunc = function (accessToken: string) {
     return axios.get('https://api.dev.snyk.io/v1/user/me', {
       headers: { 'Content-Type': 'application/json; charset=utf-8', Authorization: `bearer ${accessToken}` },
@@ -44,7 +52,6 @@ passport.use(
         scopeSeparator: ' ',
         state: true,
         passReqToCallback: true,
-        nonce: testData.nonce,
         profileFunc: fetchProfile,
       },
       // Callback function called with the
@@ -67,11 +74,21 @@ passport.use(
 
 ## Authentication Requests
 
-```
+```typescript
 import express from 'express';
 const app = express();
 
-app.get('/auth', passport.authenticate('snyk-oauth2'));
+/**
+ * Important to pass nonce value in authenticate options.
+ * Otherwise strategy will throw an error as it is a requirement.
+ * 
+ * You can also pass any query parameter you would like to be
+ * appended to the request URL.
+ */
+app.get('/auth', passport.authenticate('snyk-oauth2', {
+        state: 'test',
+        nonce: testData.nonce
+      } as passport.AuthenticateOptions));
 
 app.get(
     '/callback',

--- a/src/strategy.ts
+++ b/src/strategy.ts
@@ -3,32 +3,30 @@ import { SnykStrategyOptions, ProfileFunc, ProfileCallback } from './types';
 
 /**
  * SnykOAuth2Strategy for Passport.js to make users
- * experience with Snyk Apps authentication seamless
+ * experience with Snyk Apps authentication seamless.
  * It extends the OAuth2 strategy provided by Passport.js
  */
 export default class SnykOAuth2Strategy extends Strategy {
-  /**
-   * nonce: value is required for Snyk Authentication process
-   * profileFunc: is called is user wants to call any Snyk API
-   * to get profile for their records
-   */
-  private _nonce: string;
   private _profileFunc?: ProfileFunc;
 
   constructor(options: SnykStrategyOptions, verify: VerifyFunctionWithRequest) {
     super(options, verify);
-    this._nonce = options.nonce;
     this.name = 'snyk-oauth2';
     if (options.profileFunc) this._profileFunc = options.profileFunc;
   }
 
-  /**
-   * Function adds the nonce value to the URL being called for authentication
-   */
-  authorizationParams(): any {
-    return {
-      nonce: this._nonce,
-    };
+  authorizationParams(options: any): any {
+    if (!options || !options.nonce) {
+      throw new Error('Nonce value required, pass it in options for passport.authenticate function call.');
+    }
+    return options;
+  }
+
+  tokenParams(options: any): any {
+    if (!options || !options.nonce) {
+      throw new Error('Nonce value required, pass it in options for passport.authenticate function call.');
+    }
+    return options;
   }
 
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,6 @@ export interface SnykStrategyOptions extends StrategyOptionsWithRequest {
   clientID: string;
   clientSecret: string;
   callbackURL: string;
-  nonce: string;
   scope: string | string[];
   state: any;
   profileFunc?: ProfileFunc;

--- a/tests/helpers/setupApp.ts
+++ b/tests/helpers/setupApp.ts
@@ -29,6 +29,7 @@ export const testData = {
   callbackURL: 'https://example_callback.com',
   scope: 'apps:beta',
   nonce: 'some_nonce_value',
+  tenantId: uuidv4(),
 };
 
 /**
@@ -56,8 +57,6 @@ export function setupExpressApp(): Application {
         scopeSeparator: ' ',
         state: true,
         passReqToCallback: true,
-        nonce: testData.nonce,
-        // profileFunc,
       },
       // Callback function called with the
       // data fetched as part of authentication

--- a/tests/src/strategy.spec.ts
+++ b/tests/src/strategy.spec.ts
@@ -6,36 +6,44 @@
 import { testData, setupExpressApp } from '../helpers/setupApp';
 import supertest from 'supertest';
 import passport from 'passport';
+import SnykOAuth2Strategy from '../../src';
 
-describe('Strategy with passport', () => {
+describe('Snyk OAuth2 strategy integration test with express', () => {
   const app = setupExpressApp();
   const request = supertest(app);
 
-  // This will trigger the auth flow
-  app.get('/auth', passport.authenticate('snyk-oauth2', { state: 'test' }));
-  app.get(
-    '/callback',
-    passport.authenticate('snyk-oauth2', {
-      successRedirect: '/callback/success',
-      failureRedirect: '/callback/failure',
-    }),
-  );
-  app.get('/callback/success', (req, res) => {
-    return res.send('Test passed');
-  });
-  app.get('/callback/failure', (req, res) => {
-    return res.send('Test failed');
+  beforeAll(() => {
+    app.get(
+      '/auth',
+      passport.authenticate('snyk-oauth2', {
+        state: 'test',
+        nonce: testData.nonce,
+        tenant_id: testData.tenantId,
+      } as passport.AuthenticateOptions),
+    );
+    app.get(
+      '/callback',
+      passport.authenticate('snyk-oauth2', {
+        successRedirect: '/callback/success',
+        failureRedirect: '/callback/failure',
+      }),
+    );
+    app.get('/callback/success', (req, res) => {
+      return res.send('Test passed');
+    });
+    app.get('/callback/failure', (req, res) => {
+      return res.send('Test failed');
+    });
   });
 
   it('should redirect for authorization', async () => {
-    // Call the endpoint to trigger auth flow
+    // Action
+    // Trigger the auth flow
     const response = await request.get('/auth');
-    // From MDN: The location The Location response header indicates the URL to redirect a page to.
-    // It only provides a meaning when served with a 3xx (redirection) or 201 (created) status response.
+
+    // Assert
     expect(response.statusCode).toBe(302);
     const redirectURL = new URL(response.header.location);
-    // Assert
-    // The authorization URL
     expect(`${redirectURL.origin}${redirectURL.pathname}`).toBe(testData.authorizationURL);
     // All the query parameters
     expect(redirectURL.searchParams.get('nonce')).toBe(testData.nonce);
@@ -44,12 +52,88 @@ describe('Strategy with passport', () => {
     expect(redirectURL.searchParams.get('redirect_uri')).toBe(testData.callbackURL);
     expect(redirectURL.searchParams.get('scope')).toBe(testData.scope);
     expect(redirectURL.searchParams.get('client_id')).toBe(testData.clientID);
+    expect(redirectURL.searchParams.get('tenant_id')).toBe(testData.tenantId);
   });
 
   it('should call the failure mock when not authenticated', async () => {
+    // Action
     await request.get('/auth');
     const responseTwo = await request.get(`/callback?code=${1234}&scope=apps%3Abeta&state=test`);
+    // Assert
     expect(responseTwo.statusCode).toBe(302);
     expect(responseTwo.header.location).toBe('/callback/failure');
+  });
+});
+
+describe('SnykOAuth2 strategy unit tests', () => {
+  const strategy = new SnykOAuth2Strategy(
+    {
+      authorizationURL: testData.authorizationURL,
+      tokenURL: testData.tokenURL,
+      clientID: testData.clientID,
+      clientSecret: testData.clientSecret,
+      callbackURL: testData.callbackURL,
+      scope: testData.scope,
+      scopeSeparator: ' ',
+      state: true,
+      passReqToCallback: true,
+    },
+    (done: any) => {
+      done(null, 'Done!');
+    },
+  );
+
+  describe('authorizationParams', () => {
+    it('should throw error when auth params called with undefined', () => {
+      const action = () => {
+        strategy.authorizationParams(undefined);
+      };
+      expect(action).toThrow(
+        new Error('Nonce value required, pass it in options for passport.authenticate function call.'),
+      );
+    });
+
+    it('should throw error when auth params called with object with no nonce value', () => {
+      const action = () => {
+        strategy.authorizationParams({ test: 'test' });
+      };
+      expect(action).toThrow(
+        new Error('Nonce value required, pass it in options for passport.authenticate function call.'),
+      );
+    });
+
+    it('should not throw error when auth params called with object with nonce value', () => {
+      const action = () => {
+        strategy.authorizationParams({ nonce: 'test' });
+      };
+      expect(action).not.toThrowError();
+    });
+  });
+
+  describe('tokenParams', () => {
+    it('should throw error when token params called with undefined', () => {
+      const action = () => {
+        strategy.tokenParams(undefined);
+      };
+      expect(action).toThrow(
+        new Error('Nonce value required, pass it in options for passport.authenticate function call.'),
+      );
+    });
+
+    it('should throw error when token params called with object with no nonce value', () => {
+      const action = () => {
+        strategy.tokenParams({ test: 'test' });
+      };
+      expect(action).toThrow(
+        new Error('Nonce value required, pass it in options for passport.authenticate function call.'),
+      );
+    });
+
+    it('should not throw error when token params called with object with nonce value', () => {
+      const action = () => {
+        strategy.tokenParams({ nonce: 'test' });
+      };
+      expect(action).not.toThrowError();
+    });
   });
 });


### PR DESCRIPTION
- Removes the ability to set nonce on stratgey through constructor, when se through constructor on stratgey instance each request made will use the same nonce
- This defeats the purpose of using nonce, which needs to be unique on every request made
- With this update user can now pass nonce unique to every request by passing in as option to passport.authenticate
- Infact users can pass in any param they want to be appended to request query

BREAKING CHANGE: The ability to set nonce value through strategy constructor has been removed. It can not be set using passport.authenticate options